### PR TITLE
Change reflection, security configuration in native image mode to reflect how the documentation does it

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -218,6 +218,10 @@
           <name>native</name>
         </property>
       </activation>
+      <properties>
+        <quarkus.package.type>native</quarkus.package.type>
+        <quarkus.native.additional-build-args>-H:DynamicProxyConfigurationResources=dynamic-proxies.json,--enable-all-security-services</quarkus.native.additional-build-args>
+      </properties>
       <build>
         <plugins>
           <plugin>
@@ -229,12 +233,6 @@
                 <goals>
                   <goal>native-image</goal>
                 </goals>
-                <configuration>
-                  <additionalBuildArgs>
-                    <additionalBuildArg>-H:DynamicProxyConfigurationResources=dynamic-proxies.json</additionalBuildArg>
-                    <additionalBuildArg>--enable-all-security-services</additionalBuildArg>
-                  </additionalBuildArgs>
-                </configuration>
               </execution>
             </executions>
           </plugin>
@@ -259,9 +257,6 @@
           </plugin>
         </plugins>
       </build>
-      <properties>
-        <quarkus.package.type>native</quarkus.package.type>
-      </properties>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
I changed this because I had to edit this config and add a trust store during my manual testing. I was getting weird results for the old way.  The docs recommend using `quarkus.native.additional-build-args` and don't mention changing the `configuration` node in the pom.  I thought going forward this would be good as it lines more up to the quarkus documentation way of doing it.


Signed-off-by: Tom George <tg82490@gmail.com>