### PR TITLE
Add CI job on push to master to tag and push latest image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
         env:
           GITHUB_USERNAME: ${{ secrets.GITHUB_USERNAME }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN}}
-          ORGANIZATION: openshiftio
+          ORGANIZATION: eclipse
           TAG: dev
       - name: Log into docker registry
         run: docker login ${REGISTRY} -u ${USERNAME} -p ${PASSWORD}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
           GITHUB_USERNAME: ${{ secrets.GITHUB_USERNAME }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN}}
           ORGANIZATION: eclipse
-          TAG: dev
+          TAG: latest
       - name: Log into docker registry
         run: docker login ${REGISTRY} -u ${USERNAME} -p ${PASSWORD}
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
           docker build --build-arg GITHUB_USERNAME=${GITHUB_USERNAME} --build-arg GITHUB_TOKEN=${GITHUB_TOKEN} -t quay.io/${ORGANIZATION}/che-workspace-telemetry-woopra-plugin:${TAG} -f src/main/docker/Dockerfile.multi .
           echo "::set-env name=IMAGE::quay.io/${ORGANIZATION}/che-workspace-telemetry-woopra-plugin:${TAG}"
         env:
-          GITHUB_USERNAME: ${{ secrets.GITHUB_USERNAME }}
+          GITHUB_USERNAME: ${{ secrets.GH_USERNAME }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN}}
           ORGANIZATION: eclipse
           TAG: latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,28 @@
+name: woopra-plugin CI
+
+on: 
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build
+        run: |
+          docker build --build-arg GITHUB_USERNAME=${GITHUB_USERNAME} --build-arg GITHUB_TOKEN=${GITHUB_TOKEN} -t quay.io/${ORGANIZATION}/che-workspace-telemetry-woopra-plugin:${TAG} -f src/main/docker/Dockerfile.multi .
+          echo "::set-env name=IMAGE::quay.io/${ORGANIZATION}/che-workspace-telemetry-woopra-plugin:${TAG}"
+        env:
+          GITHUB_USERNAME: ${{ secrets.GITHUB_USERNAME }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN}}
+          ORGANIZATION: openshiftio
+          TAG: dev
+      - name: Log into docker registry
+        run: docker login ${REGISTRY} -u ${USERNAME} -p ${PASSWORD}
+        env:
+          REGISTRY: quay.io
+          USERNAME: ${{ secrets.DOCKER_REGISTRY_USERNAME }}
+          PASSWORD: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
+      - name: Push image
+        run: docker push $IMAGE

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,28 @@
+name: woopra-plugin nightly build
+
+on: 
+  schedule:
+    - cron: '0 0 * * *' # run on the 0th hour at the 0th minute every day
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build
+        run: |
+          docker build --build-arg GITHUB_USERNAME=${GITHUB_USERNAME} --build-arg GITHUB_TOKEN=${GITHUB_TOKEN} -t quay.io/${ORGANIZATION}/che-workspace-telemetry-woopra-plugin:${TAG} -f src/main/docker/Dockerfile.multi .
+          echo "::set-env name=IMAGE::quay.io/${ORGANIZATION}/che-workspace-telemetry-woopra-plugin:${TAG}"
+        env:
+          GITHUB_USERNAME: ${{ secrets.GITHUB_USERNAME }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN}}
+          ORGANIZATION: eclipse
+          TAG: nightly
+      - name: Log into docker registry
+        run: docker login ${REGISTRY} -u ${USERNAME} -p ${PASSWORD}
+        env:
+          REGISTRY: quay.io
+          USERNAME: ${{ secrets.DOCKER_REGISTRY_USERNAME }}
+          PASSWORD: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
+      - name: Push image
+        run: docker push $IMAGE

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -14,7 +14,7 @@ jobs:
           docker build --build-arg GITHUB_USERNAME=${GITHUB_USERNAME} --build-arg GITHUB_TOKEN=${GITHUB_TOKEN} -t quay.io/${ORGANIZATION}/che-workspace-telemetry-woopra-plugin:${TAG} -f src/main/docker/Dockerfile.multi .
           echo "::set-env name=IMAGE::quay.io/${ORGANIZATION}/che-workspace-telemetry-woopra-plugin:${TAG}"
         env:
-          GITHUB_USERNAME: ${{ secrets.GITHUB_USERNAME }}
+          GITHUB_USERNAME: ${{ secrets.GH_USERNAME }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN}}
           ORGANIZATION: eclipse
           TAG: nightly

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,19 @@
+name: woopra-plugin PR check
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  pr_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build
+        run: |
+          docker build --build-arg GITHUB_USERNAME=${GITHUB_USERNAME} --build-arg GITHUB_TOKEN=${GITHUB_TOKEN} -t quay.io/${ORGANIZATION}/che-workspace-telemetry-woopra-plugin:${TAG} -f src/main/docker/Dockerfile.multi .
+        env:
+          GITHUB_USERNAME: ${{ secrets.GITHUB_USERNAME  }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORGANIZATION: eclipse
+          TAG: pr-check

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -13,7 +13,7 @@ jobs:
         run: |
           docker build --build-arg GITHUB_USERNAME=${GITHUB_USERNAME} --build-arg GITHUB_TOKEN=${GITHUB_TOKEN} -t quay.io/${ORGANIZATION}/che-workspace-telemetry-woopra-plugin:${TAG} -f src/main/docker/Dockerfile.multi .
         env:
-          GITHUB_USERNAME: ${{ secrets.GITHUB_USERNAME  }}
+          GITHUB_USERNAME: ${{ secrets.GH_USERNAME  }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ORGANIZATION: eclipse
           TAG: pr-check


### PR DESCRIPTION
Required secrets to be created:

`GITHUB_USERNAME` - username to grab packages from the registry `x-access-token`
`GITHUB_TOKEN` - token to pull maven packages (this should already be created in each repo but it appears we don't have one.  We can create another personal access token for this)
`ORGANIZATION` - `openshiftio`
`TAG`- `latest`
`DOCKER_REGISTRY_USERNAME` - username to authenticate with quay
`DOCKER_REGISTRY_PASSWORD` - password to authenticate with quay