### PR TITLE
Bump dependent version of backend-base, remove CHE_API from meta.yaml

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -15,8 +15,6 @@ spec:
     - name: che-workspace-telemetry-woopra-plugin
       image: quay.io/eclipse/che-workspace-telemetry-woopra-plugin:latest
       env:
-        - name: CHE_API
-          value: $(CHE_API_INTERNAL)
         - name: WOOPRA_DOMAIN
           value: ''
         - name: SEGMENT_WRITE_KEY

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>org.eclipse.che.incubator.workspace-telemetry</groupId>
       <artifactId>backend-base</artifactId>
-      <version>0.0.12</version>
+      <version>0.0.13</version>
     </dependency>
     <dependency>
       <groupId>org.reflections</groupId>


### PR DESCRIPTION
Part of https://github.com/eclipse/che/issues/18107.  Needs to be merged after https://github.com/che-incubator/che-workspace-telemetry-client/pull/52 to pick up the bumped version of `backend-base`, `0.0.13`.

Signed-off-by: Tom George <tgeorge@redhat.com>