### PR TITLE
Bumping 'che-workspace-telemetry-client' backend base to the latest '0.0.25'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>org.eclipse.che.incubator.workspace-telemetry</groupId>
       <artifactId>backend-base</artifactId>
-      <version>0.0.13</version>
+      <version>0.0.25</version>
     </dependency>
     <dependency>
       <groupId>org.reflections</groupId>


### PR DESCRIPTION
Bumping 'che-workspace-telemetry-client' backend base to the latest '0.0.25' 