### PR TITLE
Bumping 'org.eclipse.che.incubator.workspace-telemetry' to the latest 0.0.26 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>org.eclipse.che.incubator.workspace-telemetry</groupId>
       <artifactId>backend-base</artifactId>
-      <version>0.0.25</version>
+      <version>0.0.26</version>
     </dependency>
     <dependency>
       <groupId>org.reflections</groupId>


### PR DESCRIPTION
userID / visitorID is going to be generated based on the username https://github.com/che-incubator/che-workspace-telemetry-client/pull/68